### PR TITLE
Newline after output

### DIFF
--- a/src/bin/hal/cmd/mod.rs
+++ b/src/bin/hal/cmd/mod.rs
@@ -94,4 +94,8 @@ pub fn print_output<'a, T: serde::Serialize>(matches: &clap::ArgMatches<'a>, out
 	} else {
 		serde_json::to_writer_pretty(::std::io::stdout(), &out).unwrap();
 	}
+	// Blank line after output
+	if !matches.is_present("no-newline") {
+		println!("");
+	}
 }

--- a/src/bin/hal/main.rs
+++ b/src/bin/hal/main.rs
@@ -58,6 +58,12 @@ fn init_app<'a, 'b>() -> clap::App<'a, 'b> {
 				.takes_value(false)
 				.global(true),
 		)
+		.arg(
+			cmd::opt("no-newline", "Do not print trailing newline character")
+				.short("n")
+				.takes_value(false)
+				.global(true),
+		)
 }
 
 /// The help appendix listing external subcommands.


### PR DESCRIPTION
Add global no-newline option, similar to "echo -n", that will not display the newline if requested.