### PR TITLE
Add psbt rawsign

### DIFF
--- a/src/bin/hal/cmd/miniscript.rs
+++ b/src/bin/hal/cmd/miniscript.rs
@@ -117,10 +117,10 @@ fn exec_inspect<'a>(matches: &clap::ArgMatches<'a>) {
 			.ok();
 
 		MiniscriptInfo::combine(MiniscriptInfo::combine(bare_info, p2sh_info), segwit_info)
-			.expect("Invalid Miniscript");
+			.expect("Invalid Miniscript")
 	} else {
 		MiniscriptInfo::combine(MiniscriptInfo::combine(bare_info, p2sh_info), segwit_info)
-			.unwrap();
+			.unwrap()
 	};
 	cmd::print_output(matches, &info);
 }

--- a/src/bin/hal/cmd/psbt.rs
+++ b/src/bin/hal/cmd/psbt.rs
@@ -33,6 +33,7 @@ pub fn execute<'a>(matches: &clap::ArgMatches<'a>) {
 	};
 }
 
+#[derive(Debug)]
 enum PsbtSource {
 	Base64,
 	Hex,
@@ -44,10 +45,10 @@ enum PsbtSource {
 /// the content bytes.
 /// Also returns an enum value indicating which source worked.
 fn file_or_raw(flag: &str) -> (Vec<u8>, PsbtSource) {
-	if let Ok(raw) = base64::decode(&flag) {
-		(raw, PsbtSource::Base64)
-	} else if let Ok(raw) = hex::decode(&flag) {
+	if let Ok(raw) = hex::decode(&flag) {
 		(raw, PsbtSource::Hex)
+	} else if let Ok(raw) = base64::decode(&flag) {
+		(raw, PsbtSource::Base64)
 	} else if let Ok(mut file) = File::open(&flag) {
 		let mut buf = Vec::new();
 		file.read_to_end(&mut buf).expect("error reading file");

--- a/src/bin/hal/cmd/psbt.rs
+++ b/src/bin/hal/cmd/psbt.rs
@@ -374,10 +374,6 @@ fn exec_finalize<'a>(matches: &clap::ArgMatches<'a>) {
 	let (raw, _) = file_or_raw(&matches.value_of("psbt").unwrap());
 	let mut psbt: psbt::PartiallySignedTransaction = deserialize(&raw).expect("invalid PSBT format");
 
-	if psbt.inputs.iter().any(|i| i.final_script_sig.is_none() && i.final_script_witness.is_none())
-	{
-		panic!("PSBT is missing input data!");
-	}
 
 	// Create a secp context, should there be one with static lifetime?
 	let secp = secp256k1::Secp256k1::verification_only();

--- a/src/bin/hal/process_builder.rs
+++ b/src/bin/hal/process_builder.rs
@@ -152,7 +152,7 @@ impl ProcessBuilder {
 		let exit = command.status().expect(&format!("could not execute process {}", self));
 
 		if !exit.success() {
-			panic!(format!("process didn't exit successfully: {}", self));
+			panic!("process didn't exit successfully: {}", self);
 		}
 	}
 
@@ -182,7 +182,7 @@ impl ProcessBuilder {
 		let output = command.output().expect(&format!("could not execute process {}", self));
 
 		if !output.status.success() {
-			panic!(format!("process didn't exit successfully: {}", self));
+			panic!("process didn't exit successfully: {}", self);
 		}
 	}
 

--- a/src/lightning.rs
+++ b/src/lightning.rs
@@ -14,15 +14,15 @@ pub fn parse_short_channel_id(cid: &str) -> u64 {
 	let mut split = cid.split("x");
 	let blocknum: u64 = split.next().expect(WRONG_CID).parse().expect(WRONG_CID);
 	if blocknum & 0xFFFFFF != blocknum {
-		panic!(WRONG_CID);
+		panic!("{}", WRONG_CID);
 	}
 	let txnum: u64 = split.next().expect(WRONG_CID).parse().expect(WRONG_CID);
 	if txnum & 0xFFFFFF != txnum {
-		panic!(WRONG_CID);
+		panic!("{}", WRONG_CID);
 	}
 	let outnum: u64 = split.next().expect(WRONG_CID).parse().expect(WRONG_CID);
 	if outnum & 0xFFFF != outnum {
-		panic!(WRONG_CID);
+		panic!("{}", WRONG_CID);
 	}
 	blocknum << 40 | txnum << 16 | outnum
 }


### PR DESCRIPTION
Adds `psbt rawsign <psbt> <input-idx> <priv-key> ` that adds sig to partial sigs field in psbt. Completes all roles for psbt in hal. 

Manually tested with valid test vectors from bip174 for creation, signing, finalizing, and extracting. 

It would be great to have a release with this. 

Fixes #8 