### PR TITLE
Add p2tr and xonly_pubkey support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,6 +176,7 @@ dependencies = [
  "fern",
  "hex",
  "jobserver",
+ "lazy_static",
  "lightning-invoice",
  "log",
  "miniscript",
@@ -218,6 +219,12 @@ dependencies = [
  "log",
  "rand",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,11 @@ name = "hal"
 path = "src/bin/hal/main.rs"
 
 [dependencies]
-clap = "2.32"
-log = "0.4.5"
-fern = "0.5.6"
 chrono = { version = "0.4.6", features = ["serde"] }
+clap = "2.32"
+fern = "0.5.6"
+lazy_static = "1.4"
+log = "0.4.5"
 rand = "0.4"
 
 base64-compat = "1.0.0"

--- a/src/address.rs
+++ b/src/address.rs
@@ -1,6 +1,7 @@
 use bitcoin::{self, Address, Network, Script, PubkeyHash, ScriptHash, WPubkeyHash, WScriptHash};
 use serde::{Deserialize, Serialize};
 
+use crate::SECP;
 use crate::tx;
 
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
@@ -35,6 +36,8 @@ pub struct Addresses {
 	pub p2wsh: Option<Address>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub p2shwsh: Option<Address>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub p2tr: Option<Address>,
 }
 
 impl Addresses {
@@ -43,6 +46,7 @@ impl Addresses {
 			p2pkh: Some(Address::p2pkh(pubkey, network)),
 			p2wpkh: Address::p2wpkh(pubkey, network).ok(),
 			p2shwpkh: Address::p2shwpkh(pubkey, network).ok(),
+			p2tr: Some(Address::p2tr(&SECP, pubkey.inner.into(), None, network)),
 			..Default::default()
 		}
 	}
@@ -52,6 +56,10 @@ impl Addresses {
 			p2sh: Address::p2sh(&script, network).ok(),
 			p2wsh: Some(Address::p2wsh(&script, network)),
 			p2shwsh: Some(Address::p2shwsh(&script, network)),
+			// NB to make a p2tr here we need a NUMS internal key and it's
+			// probably not safe to pick one ourselves. AFAIK there is no
+			// standard NUMS point for this purpose.
+			// (Though BIP341 suggests one..)
 			..Default::default()
 		}
 	}

--- a/src/bin/hal/cmd/address.rs
+++ b/src/bin/hal/cmd/address.rs
@@ -30,19 +30,19 @@ fn cmd_create<'a>() -> clap::App<'a, 'a> {
 fn exec_create<'a>(matches: &clap::ArgMatches<'a>) {
 	let network = cmd::network(matches);
 
-	let created = if let Some(pubkey_hex) = matches.value_of("pubkey") {
+	if let Some(pubkey_hex) = matches.value_of("pubkey") {
 		let pubkey: PublicKey = pubkey_hex.parse().expect("invalid pubkey");
-		hal::address::Addresses::from_pubkey(&pubkey, network)
+		let addr = hal::address::Addresses::from_pubkey(&pubkey, network);
+		cmd::print_output(matches, &addr)
 	} else if let Some(script_hex) = matches.value_of("script") {
 		let script_bytes = hex::decode(script_hex).expect("invalid script hex");
 		let script = script_bytes.into();
 
-		hal::address::Addresses::from_script(&script, network)
+		let addr = hal::address::Addresses::from_script(&script, network);
+		cmd::print_output(matches, &addr)
 	} else {
-		panic!("Can't create addresses without a pubkey");
-	};
-
-	cmd::print_output(matches, &created)
+		cmd_create().print_help().unwrap();
+	}
 }
 
 fn cmd_inspect<'a>() -> clap::App<'a, 'a> {

--- a/src/bin/hal/cmd/address.rs
+++ b/src/bin/hal/cmd/address.rs
@@ -1,9 +1,30 @@
+
+use std::str::FromStr;
+
 use bitcoin::hashes::Hash;
+use bitcoin::hashes::hex::FromHex;
 use bitcoin::{Address, PublicKey, WPubkeyHash, WScriptHash};
 use clap;
 
 use hal;
-use crate::cmd;
+
+use crate::{SECP, cmd, util};
+
+lazy_static! {
+	/// The H point as used in BIP-341 which is constructed by taking the hash
+	/// of the standard uncompressed encoding of the secp256k1 base point G as
+	/// X coordinate.
+	///
+	/// See: https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#constructing-and-spending-taproot-outputs
+	static ref NUMS_H: secp256k1::PublicKey = secp256k1::PublicKey::from_str(
+		"0250929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0"
+	).unwrap();
+}
+
+/// Create a NUMS point from the given entropy.
+fn nums(entropy: secp256k1::Scalar) -> secp256k1::PublicKey {
+	NUMS_H.add_exp_tweak(&SECP, &entropy).expect("invalid NUMS entropy")
+}
 
 pub fn subcommand<'a>() -> clap::App<'a, 'a> {
 	cmd::subcommand_group("address", "work with addresses")
@@ -24,6 +45,19 @@ fn cmd_create<'a>() -> clap::App<'a, 'a> {
 		cmd::opt_yaml(),
 		cmd::opt("pubkey", "a public key in hex").takes_value(true).required(false),
 		cmd::opt("script", "a script in hex").takes_value(true).required(false),
+		cmd::opt(
+			"nums-internal-key-h",
+			"use the H NUMS key from BIP-341 for p2tr address when using --script",
+		).takes_value(false).required(false),
+		cmd::opt(
+			"nums-internal-key",
+			"NUMS internal pubkey to use with --script for p2tr",
+		).takes_value(true).required(false),
+		cmd::opt(
+			"nums-internal-key-entropy",
+			"entropy to use to create NUMS internal pubkey to use with --script for p2tr\n\
+			the zero scalar is used when left empty, this means the BIP-341 NUMS point H is used",
+		).takes_value(true).required(false),
 	])
 }
 
@@ -31,17 +65,45 @@ fn exec_create<'a>(matches: &clap::ArgMatches<'a>) {
 	let network = cmd::network(matches);
 
 	if let Some(pubkey_hex) = matches.value_of("pubkey") {
-		let pubkey: PublicKey = pubkey_hex.parse().expect("invalid pubkey");
+		let pubkey = pubkey_hex.parse::<PublicKey>().expect("invalid pubkey");
 		let addr = hal::address::Addresses::from_pubkey(&pubkey, network);
 		cmd::print_output(matches, &addr)
 	} else if let Some(script_hex) = matches.value_of("script") {
 		let script_bytes = hex::decode(script_hex).expect("invalid script hex");
 		let script = script_bytes.into();
 
-		let addr = hal::address::Addresses::from_script(&script, network);
-		cmd::print_output(matches, &addr)
+		let mut ret = hal::address::Addresses::from_script(&script, network);
+
+		// If the user provided NUMS information we can add a p2tr address.
+		if util::more_than_one(&[
+			matches.is_present("nums-internal-key-h"),
+			matches.is_present("nums-internal-key"),
+			matches.is_present("nums-internal-key-entropy"),
+		]) {
+			println!("Use only either nums-h, nums-internal-key or nums-internal-key-entropy.\n");
+			cmd_create().print_help().unwrap();
+			std::process::exit(1);
+		}
+		let nums: Option<secp256k1::PublicKey> = if matches.is_present("nums-internal-key-h") {
+			Some(*NUMS_H)
+		} else if let Some(int) = matches.value_of("nums-internal-key") {
+			Some(int.parse().expect("invalid nums internal key"))
+		} else if let Some(ent) = matches.value_of("nums-internal-key-entropy") {
+			let scalar = <[u8; 32]>::from_hex(ent)
+				.expect("invalid entropy format: must be 32-byte hex");
+			Some(nums(secp256k1::Scalar::from_be_bytes(scalar).expect("invalid NUMS entropy")))
+		} else {
+			None
+		};
+		if let Some(pk) = nums {
+			let spk = script.to_v1_p2tr(&SECP, pk.into());
+			ret.p2tr = Some(Address::from_script(&spk, network).unwrap());
+		}
+
+		cmd::print_output(matches, &ret)
 	} else {
 		cmd_create().print_help().unwrap();
+		std::process::exit(1);
 	}
 }
 

--- a/src/bin/hal/cmd/bip32.rs
+++ b/src/bin/hal/cmd/bip32.rs
@@ -1,10 +1,9 @@
 use std::str::FromStr;
 
-use bitcoin::secp256k1;
 use bitcoin::util::bip32;
 use clap;
 
-use crate::cmd;
+use crate::{SECP, cmd};
 
 pub fn subcommand<'a>() -> clap::App<'a, 'a> {
 	cmd::subcommand_group("bip32", "BIP-32 key derivation")
@@ -32,20 +31,18 @@ fn exec_derive<'a>(matches: &clap::ArgMatches<'a>) {
 	let path: bip32::DerivationPath = path_str.parse().expect("error parsing derivation path");
 	let key_str = matches.value_of("ext-key").unwrap();
 
-	let secp = secp256k1::Secp256k1::new();
-
 	let master_fingerprint;
 	let mut derived_xpriv = None;
 	let derived_xpub = match bip32::ExtendedPrivKey::from_str(&key_str) {
 		Ok(ext_priv) => {
-			derived_xpriv = Some(ext_priv.derive_priv(&secp, &path).expect("derivation error"));
-			master_fingerprint = ext_priv.fingerprint(&secp);
-			bip32::ExtendedPubKey::from_priv(&secp, derived_xpriv.as_ref().unwrap())
+			derived_xpriv = Some(ext_priv.derive_priv(&SECP, &path).expect("derivation error"));
+			master_fingerprint = ext_priv.fingerprint(&SECP);
+			bip32::ExtendedPubKey::from_priv(&SECP, derived_xpriv.as_ref().unwrap())
 		}
 		Err(_) => {
 			let ext_pub: bip32::ExtendedPubKey = key_str.parse().expect("invalid extended key");
 			master_fingerprint = ext_pub.fingerprint();
-			ext_pub.derive_pub(&secp, &path).expect("derivation error")
+			ext_pub.derive_pub(&SECP, &path).expect("derivation error")
 		}
 	};
 
@@ -77,14 +74,12 @@ fn cmd_inspect<'a>() -> clap::App<'a, 'a> {
 fn exec_inspect<'a>(matches: &clap::ArgMatches<'a>) {
 	let key_str = matches.value_of("ext-key").unwrap();
 
-	let secp = bitcoin::secp256k1::Secp256k1::signing_only();
-
 	let mut xpriv = None;
 
 	let xpub = match bip32::ExtendedPrivKey::from_str(&key_str) {
 		Ok(ext_priv) => {
 			xpriv = Some(ext_priv);
-			bip32::ExtendedPubKey::from_priv(&secp, xpriv.as_ref().unwrap())
+			bip32::ExtendedPubKey::from_priv(&SECP, xpriv.as_ref().unwrap())
 		}
 		Err(_) => key_str.parse().expect("invalid extended key"),
 	};

--- a/src/bin/hal/main.rs
+++ b/src/bin/hal/main.rs
@@ -1,5 +1,7 @@
 extern crate bip39;
 extern crate bitcoin;
+#[macro_use]
+extern crate lazy_static;
 extern crate lightning_invoice;
 #[macro_use]
 extern crate log;

--- a/src/bin/hal/main.rs
+++ b/src/bin/hal/main.rs
@@ -25,6 +25,8 @@ pub mod cmd;
 mod process_builder;
 pub mod util;
 
+pub use hal::SECP;
+
 /// Setup logging with the given log level.
 fn setup_logger(lvl: log::LevelFilter) {
 	fern::Dispatch::new()

--- a/src/bin/hal/util.rs
+++ b/src/bin/hal/util.rs
@@ -157,6 +157,18 @@ pub fn find_closest(cmd: &str) -> Option<String> {
 		.map(|slot| slot.1)
 }
 
+/// Return true if more than one of the input booleans is true.
+pub fn more_than_one(bools: &[bool]) -> bool {
+	let mut one = false;
+	for b in bools {
+		if *b && one {
+			return true;
+		}
+		one |= *b;
+	}
+	false
+}
+
 #[test]
 fn test_lev_distance() {
 	use std::char::{from_u32, MAX};

--- a/src/bip39.rs
+++ b/src/bip39.rs
@@ -1,8 +1,9 @@
 use bip39lib::{Language, Mnemonic};
-use bitcoin::{secp256k1, util::bip32, Network};
+use bitcoin::Network;
+use bitcoin::util::bip32;
 use serde::{Deserialize, Serialize};
 
-use crate::{GetInfo, HexBytes};
+use crate::{SECP, GetInfo, HexBytes};
 
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 pub struct MnemonicInfo {
@@ -59,7 +60,7 @@ impl GetInfo<SeedInfo> for [u8; 64] {
 	fn get_info(&self, network: Network) -> SeedInfo {
 		let xpriv = bip32::ExtendedPrivKey::new_master(network, &self[..]).unwrap();
 		let xpub =
-			bip32::ExtendedPubKey::from_priv(&secp256k1::Secp256k1::signing_only(), &xpriv);
+			bip32::ExtendedPubKey::from_priv(&SECP, &xpriv);
 		SeedInfo {
 			seed: self.to_vec().into(),
 			bip32_xpriv: xpriv,

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,7 +1,7 @@
-use bitcoin::{Network, PrivateKey, PublicKey};
+use bitcoin::{secp256k1, Network, PrivateKey, PublicKey, XOnlyPublicKey};
 use serde::{Deserialize, Serialize};
 
-use crate::{address, GetInfo, HexBytes};
+use crate::{SECP, address, GetInfo, HexBytes};
 
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 pub struct KeyInfo {
@@ -9,8 +9,48 @@ pub struct KeyInfo {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub wif_private_key: Option<PrivateKey>,
 	pub public_key: PublicKey,
+	pub xonly_public_key: XOnlyPublicKey,
 	pub uncompressed_public_key: PublicKey,
 	pub addresses: address::Addresses,
+}
+
+impl GetInfo<KeyInfo> for PrivateKey {
+	fn get_info(&self, network: Network) -> KeyInfo {
+		let pubkey = self.public_key(&SECP);
+		KeyInfo {
+			raw_private_key: (&self.inner[..]).into(),
+			wif_private_key: Some(*self),
+			public_key: pubkey,
+			xonly_public_key: pubkey.inner.into(),
+			uncompressed_public_key: {
+				let mut uncompressed = pubkey.clone();
+				uncompressed.compressed = false;
+				uncompressed
+			},
+			addresses: address::Addresses::from_pubkey(&pubkey, network),
+		}
+	}
+}
+
+impl GetInfo<KeyInfo> for secp256k1::SecretKey {
+	fn get_info(&self, network: Network) -> KeyInfo {
+		let pubkey = secp256k1::PublicKey::from_secret_key(&SECP, self);
+		let btc_pubkey = PublicKey {
+			compressed: true,
+			inner: pubkey.clone(),
+		};
+		KeyInfo {
+			raw_private_key: self[..].into(),
+			wif_private_key: None,
+			public_key: btc_pubkey,
+			xonly_public_key: pubkey.into(),
+			uncompressed_public_key: PublicKey {
+				compressed: false,
+				inner: pubkey,
+			},
+			addresses: address::Addresses::from_pubkey(&btc_pubkey, network),
+		}
+	}
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@ extern crate bitcoin;
 extern crate byteorder;
 extern crate chrono;
 extern crate hex;
+#[macro_use]
+extern crate lazy_static;
 extern crate lightning_invoice;
 extern crate miniscript as miniscriptlib;
 extern crate secp256k1;
@@ -21,6 +23,11 @@ pub mod psbt;
 pub mod tx;
 
 use bitcoin::Network;
+
+lazy_static! {
+	/// A global secp256k1 context.
+	pub static ref SECP: secp256k1::Secp256k1<secp256k1::All> = secp256k1::Secp256k1::new();
+}
 
 /// Utility struct to serialize byte strings as hex.
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]


### PR DESCRIPTION
I added some flags to explicitly indicate which NUMS point you want to use then creating a p2tr address from just a script using `hal address create --script`.