### PR TITLE
tx: be able to convert a tx to a psbt

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ impl<'de> ::serde::Deserialize<'de> for HexBytes {
 }
 
 /// Get JSON-able objects that describe the type.
-pub trait GetInfo<T: ::serde::Serialize> {
+pub trait GetInfo<T: ::serde::Serializ e> {
 	/// Get a description of this object given the network of interest.
 	fn get_info(&self, network: Network) -> T;
 }


### PR DESCRIPTION
This is adding a small helper function to convert a tx hex into a psbt and display the information.

It is useful when debugging daemons that use hex to pass around transactions