### PR TITLE
Update rust-miniscript to 9.2.0 to avoid recursion build bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,9 +284,9 @@ checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "miniscript"
-version = "9.0.1"
+version = "9.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9601439f168c13bdc5bf84349c2e61c815be4a4dcebe8c4ff4af58f4e8a6d20"
+checksum = "152791b5a02e0841b9ff1087396e1aba9f9caf81e8b96095be483734b265c094"
 dependencies = [
  "bitcoin",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ secp256k1 = { version = "0.24.3", features = [ "recovery" ] }
 secp256k1_zkp_musig = { package = "secp256k1-zkp", git = "https://github.com/sanket1729/rust-secp256k1-zkp.git", rev = "0de61c2cc536a58f08822851528a5dfa5968d155" }
 bip39 = { version = "1.0.1", features = [ "all-languages" ] }
 lightning-invoice = "0.4.0"
-miniscript = { version = "9.0.0", features = ["compiler"] }
+miniscript = { version = "9.2.0", features = ["compiler"] }
 byteorder = "1.3.1"
 chrono = { version = "0.4.6", features = ["serde"] }
 lazy_static = "1.4"


### PR DESCRIPTION
Update miniscript to 9.2.0, mainly to include https://github.com/rust-bitcoin/rust-miniscript/pull/566