### PR TITLE
Add `miniscript script` cmd

### DIFF
--- a/src/bin/hal/cmd/miniscript.rs
+++ b/src/bin/hal/cmd/miniscript.rs
@@ -255,7 +255,6 @@ fn exec_script<'a>(args: &clap::ArgMatches<'a>) {
 	let policy_str = util::arg_or_stdin(args, "policy");
 	let script_type = args.value_of("type").unwrap();
 
-	// Try to parse as concrete policy with public keys
 	let result = policy_str
 		.parse::<policy::Concrete<bitcoin::PublicKey>>()
 		.map_err(|e| format!("Invalid concrete policy: {}", e))
@@ -276,7 +275,6 @@ fn exec_script<'a>(args: &clap::ArgMatches<'a>) {
 
 	match result {
 		Ok(script) => {
-			// Create a struct to hold both representations
 			#[derive(serde::Serialize)]
 			struct ScriptOutput {
 				hex: String,
@@ -284,7 +282,7 @@ fn exec_script<'a>(args: &clap::ArgMatches<'a>) {
 			}
 			let output = ScriptOutput {
 				hex: script.as_bytes().to_hex(),
-				asm: script.to_string(), // Bitcoin Script automatically implements Display for assembly format
+				asm: script.to_string(), 
 			};
 			
 			args.print_output(&output)

--- a/src/bin/hal/cmd/miniscript.rs
+++ b/src/bin/hal/cmd/miniscript.rs
@@ -17,7 +17,7 @@ pub fn subcommand<'a>() -> clap::App<'a, 'a> {
 		.subcommand(cmd_inspect())
 		.subcommand(cmd_parse())
 		.subcommand(cmd_policy())
-		.subcommand(cmd_script())
+		.subcommand(cmd_compile())
 }
 
 pub fn execute<'a>(args: &clap::ArgMatches<'a>) {
@@ -26,7 +26,7 @@ pub fn execute<'a>(args: &clap::ArgMatches<'a>) {
 		("inspect", Some(ref m)) => exec_inspect(&m),
 		("parse", Some(ref m)) => exec_parse(&m),
 		("policy", Some(ref m)) => exec_policy(&m),
-		("script", Some(ref m)) => exec_script(&m),
+		("compile", Some(ref m)) => exec_compile(&m),
 		(_, _) => unreachable!("clap prints help"),
 	};
 }
@@ -238,8 +238,8 @@ fn exec_policy<'a>(args: &clap::ArgMatches<'a>) {
 	}
 }
 
-fn cmd_script<'a>() -> clap::App<'a, 'a> {
-	cmd::subcommand("script", "compile a policy into a script")
+fn cmd_compile<'a>() -> clap::App<'a, 'a> {
+	cmd::subcommand("compile", "compile a policy into a script")
 		.arg(args::arg("policy", "the miniscript policy to compile").required(false))
 		.arg(
 			clap::Arg::with_name("type")
@@ -251,7 +251,7 @@ fn cmd_script<'a>() -> clap::App<'a, 'a> {
 		)
 }
 
-fn exec_script<'a>(args: &clap::ArgMatches<'a>) {
+fn exec_compile<'a>(args: &clap::ArgMatches<'a>) {
 	let policy_str = util::arg_or_stdin(args, "policy");
 	let script_type = args.value_of("type").unwrap();
 


### PR DESCRIPTION
_This PR adds a new miniscript subcommand. `script` lets to convert a miniscript policy into bitcoin script._

for instance:

```bash
> hal miniscript script "and(pk(025625f41e4a065efc06d5019cbbd56fe8c07595af1231e7cbc03fafb87ebb71ec),pk(025625f41e4a065efc06d5019cbbd56fe8c07595af1231e7cbc03fafb87ebb71ec))"

{
  "hex": "205625f41e4a065efc06d5019cbbd56fe8c07595af1231e7cbc03fafb87ebb71ecad205625f41e4a065efc06d5019cbbd56fe8c07595af1231e7cbc03fafb87ebb71ecac",
  "asm": "Script(OP_PUSHBYTES_32 5625f41e4a065efc06d5019cbbd56fe8c07595af1231e7cbc03fafb87ebb71ec OP_CHECKSIGVERIFY OP_PUSHBYTES_32 5625f41e4a065efc06d5019cbbd56fe8c07595af1231e7cbc03fafb87ebb71ec OP_CHECKSIG)"
}
```

